### PR TITLE
Convert docker-release workflow to paws

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -11,16 +11,33 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-
-concurrency:
-  group: docker-release-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
-  build:
-    name: ${{ matrix.flavor }}
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: mbround18/paws/actions/paws-up@main
+
+      - name: Resolve release version
+        id: resolve
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            version="${{ github.ref_name }}"
+          else
+            version="$(git rev-parse --short HEAD)"
+          fi
+          echo "Resolved version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  docker-release:
+    needs: version
+    name: Build ${{ matrix.flavor }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -31,53 +48,23 @@ jobs:
           - flavor: wine
             target: wine-runtime
     steps:
-      - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
-      - name: Determine whether to push
-        id: push
+      - uses: mbround18/paws/actions/paws-up@main
+
+      - name: paws docker (${{ matrix.flavor }})
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          REPO: ${{ github.repository }}
+          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ] && [ "$PR_HEAD_REPO" != "$REPO" ]; then
-            echo "value=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Log in to Docker Hub
-        if: steps.push.outputs.value == 'true'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME || 'mbround18' }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
-        with:
-          images: ${{ vars.DOCKERHUB_USERNAME || 'mbround18' }}/enshrouded-docker
-          tags: |
-            type=raw,value=${{ matrix.flavor }}-latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/') }}
-            type=semver,pattern=${{ matrix.flavor }}-{{version}}
-            type=semver,pattern=${{ matrix.flavor }}-{{major}}.{{minor}}
-            type=ref,event=pr,prefix=${{ matrix.flavor }}-pr-
-            type=sha,format=short,prefix=${{ matrix.flavor }}-
-
-      - name: Build and push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          context: .
-          file: ./Dockerfile
-          target: ${{ matrix.target }}
-          platforms: linux/amd64
-          push: ${{ steps.push.outputs.value == 'true' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.flavor }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.flavor }}
+          paws docker \
+            --image "mbround18/enshrouded-docker" \
+            --version "${{ needs.version.outputs.version }}" \
+            --target "${{ matrix.target }}" \
+            --prepend-target \
+            --registries ghcr.io \
+            --with-latest \
+            --dockerhub-username mbround18 \
+            --ghcr-username mbround18


### PR DESCRIPTION
## Summary
- Replace the `docker/build-push-action` wine/proton matrix with paws-native steps: `paws docker` per target, matching the [`mbround18/steamcmd-bases` conversion](https://github.com/mbround18/steamcmd-bases/pull/15).
- Version resolves to the pushed tag name on tag pushes, otherwise a short SHA (same behavior as before via docker/metadata-action).
- Adds ghcr.io publishing alongside docker.io (repo already had an unused `GHCR_TOKEN` secret).
- Same trigger shape as before: PRs build without pushing, pushes to `main`/tags publish for real; `latest` tags only get updated on real tag releases (unchanged from prior semver-tag gating).

## Test plan
- [ ] Open this PR and confirm both `proton`/`wine` builds succeed without pushing
- [ ] Merge to `main`, then push a `v2.1.0` tag and confirm both flavors publish to docker.io and ghcr.io with `proton-v2.1.0`/`wine-v2.1.0` (+ `-latest`) tags