### PR TITLE
Rename Dockerfile stages to wine/proton, drop -runtime suffix

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -44,9 +44,9 @@ jobs:
       matrix:
         include:
           - flavor: proton
-            target: proton-runtime
+            target: proton
           - flavor: wine
-            target: wine-runtime
+            target: wine
     steps:
       - uses: actions/checkout@v7
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ENV TZ=America/Los_Angeles
 ENV PYTHONUNBUFFERED=1 DISPLAY=:0 PUID=1000 PGID=1000
 
 # Stage 3: Wine runtime - Self-contained final image with Wine
-FROM base AS wine-runtime
+FROM base AS wine
 ARG WINEARCH=win64
 ARG WINE_MONO_VERSION=4.9.4
 ENV WINEDEBUG=fixme-all
@@ -89,7 +89,7 @@ ENV PATH=/home/steam/.local/bin:/usr/local/share/enshrouded-config:/usr/local/sb
 ENTRYPOINT ["/home/steam/scripts/entrypoint.sh"]
 
 # Stage 4: Proton runtime - Self-contained final image with Proton-GE
-FROM base AS proton-runtime
+FROM base AS proton
 # Copy pre-downloaded Proton-GE
 COPY --from=proton-download --chown=steam:steam /opt/proton /home/steam/.proton
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -74,7 +74,7 @@ async fn main() {
     // scheduled-restart job, and the post-update restart all agree on how to
     // launch it — `Instance::start()`/`restart()` from gsm-instance only know
     // how to launch via wine64 directly, which isn't on PATH on the
-    // proton-runtime image.
+    // proton image.
     fn start_server_via_proton(config: &InstanceConfig) -> Result<(), Box<dyn std::error::Error>> {
         setup_configuration(&config.working_dir);
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,7 @@ services:
       dockerfile: Dockerfile
       platforms:
         - linux/amd64
-      target: wine-runtime
+      target: wine
       cache_from:
         - type=local,src=.buildx-cache
       cache_to:
@@ -56,7 +56,7 @@ services:
       dockerfile: Dockerfile
       platforms:
         - linux/amd64
-      target: proton-runtime
+      target: proton
       cache_from:
         - type=local,src=.buildx-cache
       cache_to:


### PR DESCRIPTION
## Summary
- Follow-up to #42. `paws docker`'s `--target` flag doubles as both the `docker build --target` stage AND the tag prefix (`--prepend-target`), so this repo's `wine-runtime`/`proton-runtime` stage names leaked into published tags as `proton-runtime-v2.1.0`/`wine-runtime-v2.1.0` instead of the historical `proton-v2.1.0`/`wine-v2.1.0` pattern (see the just-published [v2.1.0 release run](https://github.com/mbround18/enshrouded-docker/actions/runs/32307754527)).
- Rename Dockerfile stages `wine-runtime`→`wine`, `proton-runtime`→`proton`, and update `compose.yaml`/`docker-release.yaml` target refs to match.
- `v2.1.0`'s tags with `-runtime` in them are already published and left alone; this only affects tag naming for future releases.

## Test plan
- [ ] Confirm PR checks build both flavors successfully with the renamed stages
- [ ] After merging, confirm the next tag push (or `workflow_dispatch`) produces clean `proton-vX.Y.Z`/`wine-vX.Y.Z` tags